### PR TITLE
Alteração das URLs da Prefeitura de BH

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ dependencies {
 
 ### Changelog
 
+1.0.2 - Atualização URLs para os ambientes de homologação e produção
+
 1.0.1 - Lançamento para ambiente de produção
 
 1.0 - Lançamento Inicial (Suporte somente ao ambiente de homologação)

--- a/nfse-bh/pom.xml
+++ b/nfse-bh/pom.xml
@@ -211,5 +211,5 @@
 			</plugin>
 		</plugins>
 	</build>
-	<version>1.0.1</version>
+	<version>1.0.2</version>
 </project>

--- a/nfse-bh/src/main/java/com/pablodomingos/util/NFSeGeraCadeiaCertificados.java
+++ b/nfse-bh/src/main/java/com/pablodomingos/util/NFSeGeraCadeiaCertificados.java
@@ -20,11 +20,11 @@ public class NFSeGeraCadeiaCertificados {
   public static byte[] geraCadeiaCertificados(String senha) throws Exception {
     
     KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());  
-    ks.load(null, senha.toCharArray());   
-      
-    get("bhisshomologa.pbh.gov.br", PORT, ks); 
-    get("bhissdigital.pbh.gov.br", PORT, ks); 
-    
+    ks.load(null, senha.toCharArray());
+
+    get("bhisshomologaws.pbh.gov.br", PORT, ks);
+    get("bhissdigitalws.pbh.gov.br", PORT, ks);
+
     ByteArrayOutputStream out = new ByteArrayOutputStream(); 
     ks.store(out, senha.toCharArray());
     

--- a/nfse-bh/src/main/java/com/pablodomingos/webservices/pbh/NfseWSServiceLocator.java
+++ b/nfse-bh/src/main/java/com/pablodomingos/webservices/pbh/NfseWSServiceLocator.java
@@ -12,14 +12,14 @@ import com.pablodomingos.classes.rps.enums.NFSeAmbiente;
 public class NfseWSServiceLocator extends org.apache.axis.client.Service implements com.pablodomingos.webservices.pbh.NfseWSService {
     
     private NFSeAmbiente ambiente = NFSeAmbiente.HOMOLOGACAO;
-    private java.lang.String nfseSOAP_address = "https://bhisshomologa.pbh.gov.br:443/bhiss-ws/nfse";
+    private java.lang.String nfseSOAP_address = "https://bhisshomologaws.pbh.gov.br:443/bhiss-ws/nfse";
     
     public NfseWSServiceLocator() {
     }
 
     public NfseWSServiceLocator(NFSeAmbiente ambiente) {
       if(ambiente.equals(NFSeAmbiente.PRODUCAO)){
-        nfseSOAP_address = "https://bhissdigital.pbh.gov.br:443/bhiss-ws/nfse";
+        nfseSOAP_address = "https:///bhissdigitalws.pbh.gov.br:443/bhiss-ws/nfse";
       }
       this.ambiente = ambiente;
     }

--- a/nfse-bh/src/main/java/com/pablodomingos/webservices/pbh/NfseWSServiceLocator.java
+++ b/nfse-bh/src/main/java/com/pablodomingos/webservices/pbh/NfseWSServiceLocator.java
@@ -19,7 +19,7 @@ public class NfseWSServiceLocator extends org.apache.axis.client.Service impleme
 
     public NfseWSServiceLocator(NFSeAmbiente ambiente) {
       if(ambiente.equals(NFSeAmbiente.PRODUCAO)){
-        nfseSOAP_address = "https:///bhissdigitalws.pbh.gov.br:443/bhiss-ws/nfse";
+        nfseSOAP_address = "https://bhissdigitalws.pbh.gov.br:443/bhiss-ws/nfse";
       }
       this.ambiente = ambiente;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>com.github.pablopdomingos</groupId>
 	<artifactId>nfse</artifactId>
 	<packaging>pom</packaging>
-	<version>1.0.1</version>
+	<version>1.0.2</version>
 
 	<name>NFSe</name>
 	<description>Api para geração, transmissão e assinatura da Nota Fiscal de Serviços</description>


### PR DESCRIPTION
As URL foram alteradas para atendimento ao aviso:

NFS-e – Alteração da URL de acesso ao Web Service da NFS-e
Data: 01/02/2024

Presente no site: https://prefeitura.pbh.gov.br/fazenda/bhiss